### PR TITLE
[Feat] MemePost 사용자 게시글 목록 조회 시 사용자 관련정보 추가, 미로그인 시에도 조회 가능하도록 변경

### DIFF
--- a/src/main/java/com/findmymeme/common/dto/UserProfileResponse.java
+++ b/src/main/java/com/findmymeme/common/dto/UserProfileResponse.java
@@ -1,0 +1,25 @@
+package com.findmymeme.common.dto;
+
+import com.findmymeme.user.domain.User;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class UserProfileResponse {
+    private String username;
+    private String profileImageUrl;
+    private String role;
+
+    @Builder
+    public UserProfileResponse(String username, String profileImageUrl, String role) {
+        this.username = username;
+        this.profileImageUrl = profileImageUrl;
+        this.role = role;
+    }
+
+    public UserProfileResponse(User user) {
+        this.username = user.getUsername();
+        this.profileImageUrl = user.getProfileImageUrl();
+        this.role = user.getRole().name();
+    }
+}

--- a/src/main/java/com/findmymeme/memepost/api/MemePostController.java
+++ b/src/main/java/com/findmymeme/memepost/api/MemePostController.java
@@ -115,15 +115,21 @@ public class MemePostController {
     }
 
     @GetMapping("/users/{authorName}")
-    public ResponseEntity<ApiResponse<MySlice<MemePostSummaryResponse>>> getMemePostsByAuthorId(
+    public ResponseEntity<ApiResponse<MemePostUserSummaryResponse>> getMemePostsByAuthorId(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @PathVariable("authorName") String authorName,
             Authentication authentication
     ) {
-        Long userId = Long.parseLong(authentication.getName());
+        MemePostUserSummaryResponse responses = null;
+        if (authentication == null) {
+            responses = memePostService.getMemePostsByAuthorId(page, size, authorName);
+        } else {
+            Long userId = Long.parseLong(authentication.getName());
+            responses =  memePostService.getMemePostsByAuthorId(page, size, authorName, userId);
+        }
         return ResponseUtil.success(
-                new MySlice<>(memePostService.getMemePostsByAuthorId(page, size, authorName, userId)),
+                responses,
                 SuccessCode.MEME_POST_AUTHOR_LIST
         );
     }

--- a/src/main/java/com/findmymeme/memepost/dto/MemePostUserSummaryResponse.java
+++ b/src/main/java/com/findmymeme/memepost/dto/MemePostUserSummaryResponse.java
@@ -1,0 +1,20 @@
+package com.findmymeme.memepost.dto;
+
+import com.findmymeme.common.dto.UserProfileResponse;
+import com.findmymeme.response.MySlice;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemePostUserSummaryResponse {
+    private UserProfileResponse user;
+    private MySlice<MemePostSummaryResponse> memePosts;
+
+    @Builder
+    public MemePostUserSummaryResponse(UserProfileResponse user, MySlice<MemePostSummaryResponse> memePosts) {
+        this.user = user;
+        this.memePosts = memePosts;
+    }
+}

--- a/src/main/java/com/findmymeme/memepost/repository/MemePostRepository.java
+++ b/src/main/java/com/findmymeme/memepost/repository/MemePostRepository.java
@@ -25,6 +25,11 @@ public interface MemePostRepository extends JpaRepository<MemePost, Long> {
             "FROM MemePost mp WHERE mp.deletedAt IS NULL")
     Slice<MemePostSummaryResponse> findMemePostSummariesWithLike(Pageable pageable, @Param("userId") Long userId);
 
+    @Query("SELECT mp FROM MemePost mp WHERE mp.deletedAt IS NULL AND mp.user.username = :authorName")
+    Slice<MemePost> findMemePostByUserId(
+            Pageable pageable,
+            @Param("authorName") String authorName);
+
     @Query("SELECT new com.findmymeme.memepost.dto.MemePostSummaryResponse(mp, " +
             "EXISTS (SELECT 1 FROM MemePostLike mpl WHERE mpl.memePost = mp AND mpl.user.id = :currentUserId)) " +
             "FROM MemePost mp WHERE mp.deletedAt IS NULL AND mp.user.username = :authorName")


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  close #Issue_number를 적어주세요 -->
close #105 

## 📌 PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

## ✨ 이슈 내용
MemePost 사용자 게시글 목록 조회 시 사용자 관련정보 추가, 미로그인 시에도 조회 가능하도록 변경

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
