### PR TITLE
feat(memepost): SQS 메시지 처리 및 이미지 완료 이벤트 처리 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 	//AWS
 	implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:${springCloudAwsVersion}")
 	implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3'
+	implementation 'io.awspring.cloud:spring-cloud-aws-starter-sqs'
 	implementation 'software.amazon.awssdk:lambda'
 
 	//XML binding

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -16,7 +16,7 @@ services:
       - "4566:4566"            # 모든 서비스의 공용 엔드포인트
       - "4510-4559:4510-4559"  # 레거시 개별 서비스 엔드포인트 (필요시)
     environment:
-      - SERVICES=s3,lambda     # 사용할 AWS 서비스 목록을 지정합니다.
+      - SERVICES=s3,lambda,sqs     # 사용할 AWS 서비스 목록을 지정합니다.
       - DEBUG=1                # 디버그 로그 활성화
       - PERSISTENCE=1          # 데이터 영속성 활성화를 명시
       - DATA_DIR=/var/lib/localstack/data

--- a/init-aws.sh
+++ b/init-aws.sh
@@ -25,3 +25,6 @@ awslocal lambda create-function \
   --zip-file fileb:///tmp/lambda-dummy/dummy-handler.zip
 
 echo "Mock Lambda function 'local-image-resizer' created."
+
+awslocal sqs create-queue --queue-name local-image-complete-queue
+echo "SQS queue 'local-image-complete-queue' created."

--- a/src/main/java/com/findmymeme/config/SqsConfig.java
+++ b/src/main/java/com/findmymeme/config/SqsConfig.java
@@ -1,0 +1,25 @@
+package com.findmymeme.config;
+
+import io.awspring.cloud.sqs.config.SqsMessageListenerContainerFactory;
+import io.awspring.cloud.sqs.listener.acknowledgement.handler.AcknowledgementMode;
+import io.awspring.cloud.sqs.listener.errorhandler.ErrorHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+@Configuration
+public class SqsConfig {
+
+    @Bean
+    public SqsMessageListenerContainerFactory<Object> defaultSqsListenerContainerFactory(
+            SqsAsyncClient sqsAsyncClient, ErrorHandler<Object> sqsErrorHandler) {
+
+        return SqsMessageListenerContainerFactory
+                .builder()
+                .configure(options -> options
+                        .acknowledgementMode(AcknowledgementMode.MANUAL)
+                )
+                .sqsAsyncClient(sqsAsyncClient)
+                .build();
+    }
+}

--- a/src/main/java/com/findmymeme/exception/FindMyMemeException.java
+++ b/src/main/java/com/findmymeme/exception/FindMyMemeException.java
@@ -11,6 +11,11 @@ public class FindMyMemeException extends RuntimeException {
         this.errorCode = errorCode;
     }
 
+    public FindMyMemeException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
     public FindMyMemeException(String message, Throwable cause, ErrorCode errorCode) {
         super(message, cause);
         this.errorCode = errorCode;

--- a/src/main/java/com/findmymeme/memepost/domain/MemePost.java
+++ b/src/main/java/com/findmymeme/memepost/domain/MemePost.java
@@ -127,6 +127,11 @@ public class MemePost extends BaseEntity {
         this.processingStatus = status;
     }
 
+    public void updateThumbnails(String thumbnail288Url, String thumbnail657Url) {
+        this.thumbnail288Url = thumbnail288Url;
+        this.thumbnail657Url = thumbnail657Url;
+    }
+
     public void softDelete() {
         this.deletedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/findmymeme/memepost/dto/ImageCompletionDto.java
+++ b/src/main/java/com/findmymeme/memepost/dto/ImageCompletionDto.java
@@ -1,0 +1,29 @@
+package com.findmymeme.memepost.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/**
+ * 이미지 처리 완료 후 SQS를 통해 전달되는 DTO
+ */
+@Getter
+@ToString
+@NoArgsConstructor
+public class ImageCompletionDto {
+
+    @NotNull(message = "memePostId는 필수입니다.")
+    private Long memePostId;
+
+    @NotNull(message = "userId는 필수입니다.")
+    private Long userId;
+
+    @NotBlank(message = "thumbnail288Url은 비어있을 수 없습니다.")
+    private String thumbnail288Url;
+
+    @NotBlank(message = "thumbnail657Url은 비어있을 수 없습니다.")
+    private String thumbnail657Url;
+    private String status;
+}

--- a/src/main/java/com/findmymeme/memepost/service/ImageCompletionListener.java
+++ b/src/main/java/com/findmymeme/memepost/service/ImageCompletionListener.java
@@ -1,0 +1,106 @@
+package com.findmymeme.memepost.service;
+
+import com.findmymeme.exception.ErrorCode;
+import com.findmymeme.exception.FindMyMemeException;
+import com.findmymeme.memepost.dto.ImageCompletionDto;
+import io.awspring.cloud.sqs.annotation.SqsListener;
+import io.awspring.cloud.sqs.listener.acknowledgement.Acknowledgement;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * SQS 메시지를 수신하고 처리하는 메인 리스너
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ImageCompletionListener {
+
+    private final MemePostService memePostService;
+    private final Validator validator;
+
+    @SqsListener("${aws.sqs.image-completion-queue}")
+    public void handleImageCompletion(@Payload ImageCompletionDto dto, Acknowledgement ack) {
+        log.info("SQS message received. postId={}, status={}", dto.getMemePostId(), dto.getStatus());
+
+        try {
+            validateDto(dto);
+
+            if ("SUCCESS".equals(dto.getStatus())) {
+                processSuccess(dto);
+            } else {
+                processFailure(dto, "Invalid status");
+            }
+
+            ack.acknowledge();
+            log.info("Message acknowledged. postId={}", dto.getMemePostId());
+
+        } catch (Exception e) {
+            handleError(dto, e, ack);
+        }
+    }
+
+    private void validateDto(ImageCompletionDto dto) {
+        Set<ConstraintViolation<ImageCompletionDto>> violations = validator.validate(dto);
+        if (!violations.isEmpty()) {
+            String errorMessage = violations.stream()
+                    .map(v -> v.getPropertyPath() + ": " + v.getMessage())
+                    .collect(Collectors.joining(", "));
+            throw new FindMyMemeException(errorMessage, ErrorCode.REQUEST_INVALID_INPUT);
+        }
+    }
+
+    private void processSuccess(ImageCompletionDto dto) {
+        memePostService.updatePostAfterProcessing(
+                dto.getMemePostId(),
+                dto.getThumbnail288Url(),
+                dto.getThumbnail657Url()
+        );
+        log.info("Post updated successfully. postId={}", dto.getMemePostId());
+    }
+
+    private void processFailure(ImageCompletionDto dto, String errorMessage) {
+        memePostService.updatePostToFailed(dto.getMemePostId(), errorMessage);
+        log.warn("Failure status message processed. postId={}, reason={}", dto.getMemePostId(), errorMessage);
+    }
+
+    private void handleError(ImageCompletionDto dto, Throwable e, Acknowledgement ack) {
+        Throwable rootCause = getRootCause(e);
+
+        if (isNonRetryable(rootCause)) {
+            log.warn("Non-retryable error. Message will be acknowledged. postId={}, reason={}",
+                    dto.getMemePostId(), rootCause.getMessage());
+            if (dto.getMemePostId() != null) {
+                memePostService.updatePostToFailed(dto.getMemePostId(), rootCause.getMessage());
+            }
+            ack.acknowledge();
+        } else {
+            log.error("Retryable error occurred. Message will be retried. postId={}, error={}",
+                    dto.getMemePostId(), rootCause.getMessage(), rootCause);
+            throw new RuntimeException(rootCause);
+        }
+    }
+
+    private boolean isNonRetryable(Throwable cause) {
+        if (cause instanceof FindMyMemeException e) {
+            return e.getErrorCode() == ErrorCode.REQUEST_INVALID_INPUT ||
+                    e.getErrorCode() == ErrorCode.NOT_FOUND_MEME_POST;
+        }
+        return false;
+    }
+
+    private Throwable getRootCause(Throwable throwable) {
+        Throwable root = throwable;
+        while (root.getCause() != null && root.getCause() != root) {
+            root = root.getCause();
+        }
+        return root;
+    }
+}

--- a/src/main/java/com/findmymeme/memepost/service/MemePostService.java
+++ b/src/main/java/com/findmymeme/memepost/service/MemePostService.java
@@ -9,6 +9,7 @@ import com.findmymeme.file.repository.FileMetaRepository;
 import com.findmymeme.file.service.FileStorageService;
 import com.findmymeme.memepost.domain.MemePost;
 import com.findmymeme.memepost.domain.MemePostSort;
+import com.findmymeme.memepost.domain.ProcessingStatus;
 import com.findmymeme.memepost.dto.*;
 import com.findmymeme.memepost.dto.Sort;
 import com.findmymeme.memepost.repository.MemePostLikeRepository;
@@ -68,6 +69,22 @@ public class MemePostService {
             log.warn("MemePost 저장 실패: userId={}, permanentImageUrl={}", userId, permanentImageUrl, e);
             throw e;
         }
+    }
+
+    @Transactional
+    public void updatePostAfterProcessing(Long memePostId, String thumbnail288Url, String thumbnail657Url) {
+        MemePost memePost = getMemePostById(memePostId);
+        memePost.updateThumbnails(thumbnail288Url, thumbnail657Url);
+        memePost.changeProcessingStatus(ProcessingStatus.READY);
+    }
+
+
+    @Transactional
+    public void updatePostToFailed(Long memePostId, String errorMessage) {
+        memePostRepository.findById(memePostId).ifPresent(memePost -> {
+            memePost.changeProcessingStatus(ProcessingStatus.FAILED);
+            log.warn("MemePost(id:{}) 상태를 FAILED로 변경합니다. 원인: {}", memePostId, errorMessage);
+        });
     }
 
     @Transactional

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -58,10 +58,11 @@ file:
 aws:
   s3:
     bucket: find-my-meme
-
     presigned-duration: 5
   lambda:
     function-name: local-image-resizer
+  sqs:
+    image-completion-queue: local-image-complete-queue
 
 default:
   profile-image-url: images/6372d43a-81e8-4464-9998-4a1c1cd1267e.jpg

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -65,6 +65,8 @@ aws:
     presigned-duration: 5
   lambda:
     function-name: ${LAMBDA_FUNCTION_NAME}
+  sqs:
+    image-completion-queue: ${IMAGE_COMPLETION_QUEUE}
 
 allowed:
   origins: ${ALLOWED_ORIGIN}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -63,10 +63,11 @@ file:
 aws:
   s3:
     bucket: find-my-meme
-
     presigned-duration: 5
   lambda:
     function-name: local-image-resizer
+  sqs:
+    image-completion-queue: local-image-complete-queue
 
 default:
   profile-image-url: images/6372d43a-81e8-4464-9998-4a1c1cd1267e.jpg


### PR DESCRIPTION
- SQS 지원을 위한 `spring-cloud-aws-starter-sqs` 의존성 추가.
- SQS 메시지 리스너 `ImageCompletionListener` 추가 및 로직 구현.
- `MemePost` 도메인과 서비스에 이미지 처리 상태 및 썸네일 업데이트 메서드 추가.
- 로컬 및 프로덕션 설정 파일에 SQS 큐 설정 추가.
- `docker-compose-local.yml`에 SQS 서비스 활성화.

related:  #261

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  close #Issue_number를 적어주세요 -->

## 📌 PR Type
<!— Please check the one that applies to this PR using "x". —>

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

## ✨ 이슈 내용
 SQS 메시지 처리 및 이미지 완료 이벤트 처리 기능 구현

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
